### PR TITLE
Pass params as objects

### DIFF
--- a/src/core/Branch.ts
+++ b/src/core/Branch.ts
@@ -22,13 +22,20 @@ export default class Branch {
         this.to = to;
     }
 
-    state(id: string, message: string, catchMessage: string, matchFunction: MatchFunction): State {
-        const newState = new State(id, {
-            text: message
+    state(newBranchStateParams: NewBranchStateParams): State {
+        const newState = new State(newBranchStateParams.id, {
+            text: newBranchStateParams.message
         }, {
-            text: catchMessage
-        }, matchFunction);
+            text: newBranchStateParams.catchMessage
+        }, newBranchStateParams.matchFunction);
         this.addTo(newState);
         return newState;
     }
 }
+
+export interface NewBranchStateParams {
+    id: string,
+    message: string,
+    catchMessage: string,
+    matchFunction: MatchFunction
+};

--- a/src/core/Flow.ts
+++ b/src/core/Flow.ts
@@ -43,19 +43,17 @@ export default class Flow {
         }
     }
 
-    createState(id: string, message: string, catchMessage: string, createStateCallback?: CreateStateCallback, matchFunction?: MatchFunction): Flow {
-        const matchFunctionDefined = matchFunction ? matchFunction : this.options.defaultMatchFunction;
+    createState(newStateParams: NewFlowStateParams): Flow {
+        const matchFunctionDefined = newStateParams.matchFunction ?? this.options.defaultMatchFunction;
         if (!matchFunctionDefined) throw "Missing matchFn";
 
-        const newState = new State(id, {
-            text: message
+        const newState = new State(newStateParams.id, {
+            text: newStateParams.message
         }, {
-            text: catchMessage
+            text: newStateParams.catchMessage
         }, matchFunctionDefined);
 
-        if (createStateCallback) {
-            createStateCallback(newState, this);
-        }
+        if (newStateParams.createStateCallback) newStateParams.createStateCallback(newState, this); 
 
         this.addStates(newState);
         return this;
@@ -79,3 +77,11 @@ export interface FlowOptions {
     defaultStateId?: string,
     defaultMatchFunction?: MatchFunction
 }
+
+export interface NewFlowStateParams {
+    id: string,
+    message: string,
+    catchMessage: string,
+    createStateCallback?: CreateStateCallback,
+    matchFunction?: MatchFunction
+};

--- a/test/core/Flow.test.ts
+++ b/test/core/Flow.test.ts
@@ -11,11 +11,21 @@ beforeEach(() => {
     });
 
     flow
-        .createState("start", "Olá meu povo!", "Desculpe, não entendi vc!", (newState) => {
-            newState
-                .branch("Oi")
-                .state("end", "Foi bom te ver", "Tu é muito chato, não te entendo!", labelEqualsText);
-            return;
+        .createState({
+            id: "start",
+            message: "Olá meu povo!",
+            catchMessage: "Desculpe, não entendi vc!",
+            createStateCallback: (newState) => {
+                newState
+                    .branch("Oi")
+                        .state({
+                            id: "end",
+                            message: "Foi bom te ver",
+                            catchMessage: "Tu é muito chato, não te entendo!",
+                            matchFunction: labelEqualsText
+                        });
+                return;
+            }
         });
 });
 
@@ -43,8 +53,12 @@ test("Testando create state sem match Fn", () => {
     const catchFn = jest.fn();
     try {
         flow.options.defaultMatchFunction = undefined;
-        flow.createState("test", "Mensagem", "Defeito");
-    } catch(e) {
+        flow.createState({
+            id: "test",
+            message: "Mensagem",
+            catchMessage: "Defeito"
+        });
+    } catch (e) {
         catchFn(e);
     }
     expect(catchFn).toBeCalled();
@@ -56,7 +70,7 @@ test("Default state - throw", () => {
         flow.options.defaultState = undefined;
         flow.options.defaultStateId = undefined;
         flow.getDefaultState();
-    } catch(e) {
+    } catch (e) {
         catchFn(e);
     }
     expect(catchFn).toBeCalled();
@@ -66,7 +80,7 @@ test("Get state by id - not found", () => {
     const catchFn = jest.fn();
     try {
         flow.getStateById('a');
-    } catch(e) {
+    } catch (e) {
         catchFn(e);
     }
     expect(catchFn).toBeCalled();

--- a/test/demo.ts
+++ b/test/demo.ts
@@ -1,7 +1,7 @@
 import { question } from 'readline-sync';
 import crypto from 'crypto';
 
-import Flow from '../src/core/Flow';
+import Flow, { NewFlowStateParams } from '../src/core/Flow';
 import Machine from '../src/core/Machine';
 
 import ClientMemoryRepository from '../src/repositories/ClientMemory.repository';
@@ -18,17 +18,62 @@ const flow = new Flow({
     defaultMatchFunction: labelEqualsTextOrNumber
 });
 
-flow.createState("start", "Olá, aqui é o plínio.", "Desculpa, não te entendi", (newState) => {
-    const educado = newState.branch("Olá").state("educado", "Que bom saber que você é um cliente educado", "Eu não te entendi meu bom amigo", labelEqualsTextOrNumber)
+const newFlowStateParams: NewFlowStateParams = {
+    id: "start",
+    message: "Olá, aqui é o plínio.",
+    catchMessage: "Desculpa, não te entendi",
+    createStateCallback: (newState) => {
+        const educado = newState.branch("Olá")
+            .state({
+                id: "educado",
+                message: "Que bom saber que você é um cliente educado",
+                catchMessage: "Eu não te entendi meu bom amigo",
+                matchFunction: labelEqualsTextOrNumber
+            });
 
-    educado.branch("Sou mesmo!").state("soumemo", "Ish, que arrogância", "Eu não te entendi arrogante.", labelEqualsTextOrNumber)
-    educado.branch("Será!?").state("sera", "Aí vc me complica compadre", "Não te entendi compadre", labelEqualsTextOrNumber);
+                educado.branch("Sou mesmo!")
+                    .state({
+                        id: "soumemo",
+                        message: "Ish, que arrogância",
+                        catchMessage: "Eu não te entendi arrogante.",
+                        matchFunction: labelEqualsTextOrNumber
+                    });
 
-    const chato = newState.branch("Hum").state("chato", "Que difícil hein, vc é um cara chato, que pena", "Fala de novo", labelEqualsTextOrNumber);
+                educado.branch("Será!?")
+                    .state({
+                        id: "sera",
+                        message: "Aí vc me complica compadre",
+                        catchMessage: "Não te entendi compadre",
+                        matchFunction: labelEqualsTextOrNumber
+                    });
 
-    chato.branch("Sou mesmo!").state("souchatomemo", "Ish, que arrogância", "Eu não te entendi arrogante.", labelEqualsTextOrNumber)
-    chato.branch("Não sou não!").state("naosouchato", "Vamos descobrir", "Eu não te entendi inoscente.", labelEqualsTextOrNumber);
-});
+        const chato = newState.branch("Hum")
+            .state({
+                id: "chato",
+                message: "Que difícil hein, vc é um cara chato, que pena",
+                catchMessage: "Fala de novo",
+                matchFunction: labelEqualsTextOrNumber
+            });
+
+                chato.branch("Sou mesmo!")
+                    .state({
+                        id: "souchatomemo",
+                        message: "Ish, que arrogância",
+                        catchMessage: "Eu não te entendi arrogante.",
+                        matchFunction: labelEqualsTextOrNumber
+                    });
+
+                chato.branch("Não sou não!")
+                    .state({
+                        id: "naosouchato",
+                        message: "Vamos descobrir",
+                        catchMessage: "Eu não te entendi inoscente.",
+                        matchFunction: labelEqualsTextOrNumber
+                    });
+    }
+}
+
+flow.createState(newFlowStateParams);
 
 const machine = new Machine(flow, clientRepository, sendMessageGateway);
 


### PR DESCRIPTION
When creating a flow and it states, was getting a little mess in the code and hard to distinguise what was what.

Then i thought of using objects as parameters and a change in the indentation, so that was gonna make it better reading of the whole Flow proccess and make the code cleaner.

I created two interfaces for two different cases of use, which is:

- When creating the first state of a flow you have two optional params: `createStateCallback` and `matchFunction`;
- And when creating a state for a branch, you have to pass only the matchFn _(compared with the flow)_.

After that, i implemented this new changes to the `demo.ts` , creating a `const newFlowParams`, setting all the flow inside of if, and then passing to the `flow.createState`.

After it i applied some indentation to the final result.